### PR TITLE
method to trim review on BTiles if length > 140

### DIFF
--- a/app/javascript/react/components/Breweries/BreweryTile.js
+++ b/app/javascript/react/components/Breweries/BreweryTile.js
@@ -3,8 +3,19 @@ import { Link } from "react-router-dom"
 
 const BreweryTile = (props) => {
   const logo = `https://logo.clearbit.com/${props.website}?size=260`
-
   const recentReviewObject = props.reviews[(props.reviews).length-1]
+
+  const trimRecentReview = () => {
+    const recentReview = recentReviewObject.body
+    if (recentReview.length > 140) {
+      console.log('recent review is longer than 75 chars')
+      return recentReview.substring(0,140) + '...'
+    } else {
+      console.log('recent review is shorter than 75 chars')
+      return recentReview
+    }
+  }
+
   return (
     <div className="brewery-tile-container row">
       <div className="brewery-tile small-4 columns">
@@ -21,7 +32,7 @@ const BreweryTile = (props) => {
               <h3>{props.name}</h3>
               <div className="recent-review text-center">
                 <p className="recent-review-rating">{recentReviewObject.rating}</p>
-                <p className="recent-review-body">"{recentReviewObject.body}"</p> 
+                <p className="recent-review-body">"{trimRecentReview()}"</p> 
                 <p className="recent-review-username">-{recentReviewObject.username}</p>
               </div>
             </figcaption>


### PR DESCRIPTION
Created method to trim recent reviews displayed on brewery tiles if the length of the review is greater than 140 characters.  If review is longer than 140 characters then the review will be trimmed and "..." will be placed after it.